### PR TITLE
Pass the request body (don't assume this.request.body set)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index",
   "dependencies": {
     "iconv-lite": "^0.2.11",
-    "co-request": "^0.2.0"
+    "co-request": "^0.2.0",
+    "raw-body": "^1.3.0"
   },
   "keywords": [
     "koa",


### PR DESCRIPTION
This addresses the same issue as [pull request #8](https://github.com/popomore/koa-proxy/pull/8), but with a different approach.

A proxy should preserve the original request as much as possible. It's not safe to assume what body parser (if any) an application is using, and it's not ideal to re-stringify a body that's already been parsed to an object. Instead, it seems preferable to get the original, raw request body and pass it through to the destination server.

I took a slightly different approach to testing this as well. The key thing to validate is that the original request is passed-through to the destination server unchanged – so rather than validate a response from the server, I just validate the request body in the destination app's middleware. (This required creating a separate destination app than the one in the setup).

Let me know what you think.
