### PR TITLE
'match' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ app.get('index.js', proxy({
 }));
 ```
 
-## LISENCE
+You can specify match criteria to restrict proxy calls to a given path.
+
+```
+app.use(proxy({
+  host:  'http://alicdn.com', // proxy alicdn.com...
+  match: /^\/static\//        // ...just the /static folder
+}));
+```
+
+Or you can use match to exclude a specific path.
+
+```
+app.use(proxy({
+  host:  'http://alicdn.com',     // proxy alicdn.com...
+  match: /^(?!\/dontproxy\.html)/ // ...everything except /dontproxy.html
+}));
+```
+
+## LICENSE
 
 Copyright (c) 2014 popomore. Licensed under the MIT license.

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function(options) {
       body: parsedBody
     };
     // set 'Host' header to options.host (without protocol prefix)
-    opt.headers.host = options.host.slice(options.host.indexOf('://')+3)
+    if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3)
 
     var requestThunk = request(opt);
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,13 @@ module.exports = function(options) {
       return yield* next;
     }
 
+    // if match option supplied, restrict proxy to that match
+    if (options.match) {
+      if (!this.path.match(options.match)) {
+        return yield* next;
+      }
+    }
+
     var parsedBody = getParsedBody(this);
 
     var opt = {

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ module.exports = function(options) {
       method: this.method,
       body: parsedBody
     };
+    // set 'Host' header to options.host (without protocol prefix)
+    opt.headers.host = options.host.slice(options.host.indexOf('://')+3)
 
     var requestThunk = request(opt);
 

--- a/test/index.js
+++ b/test/index.js
@@ -122,6 +122,28 @@ describe('koa-proxy', function() {
       });
   });
 
+  it('should have option host and match', function(done) {
+    var app = koa();
+    app.use(proxy({
+      host: 'http://localhost:1234',
+      match: /^\/[a-z]+\.js$/
+    }));
+    app.use(proxy({
+      host: 'http://localhost:1234'
+    }));
+    var server = http.createServer(app.callback());
+    request(server)
+      .get('/class.js')
+      .expect(200)
+      .expect('Content-Type', /javascript/)
+      .end(function (err, res) {
+        if (err)
+          return done(err);
+        res.text.should.startWith('define("arale/class/1.0.0/class"');
+        done();
+      });
+  });
+
   it('url not match for url', function(done) {
     var app = koa();
     app.use(proxy({


### PR DESCRIPTION
Adds 'match' option to restrict proxying to specified match. Can also be used to exclude a path, hence addressing issue #2.

Also sets the 'Host' header, as otherwise it wouldn't work for me!