### PR TITLE
修改文档错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ You can proxy a specified url.
 
 ```
 app.get('index.js', proxy({
-  url: 'http://alicdn.com/index.js'
+  host: 'http://alicdn.com',
+  url: '/index.js'
 }));
 ```
 


### PR DESCRIPTION
纯url代理的配置参数不能只有url，必须还要有host，否则request的时候header里的host是locahost，导致被代理服务器返回错误的页面