### PR TITLE
strip trailing slash from headers.host

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ module.exports = function(options) {
       method: this.method,
       body: parsedBody
     };
-    // set 'Host' header to options.host (without protocol prefix)
-    if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3)
+    // set 'Host' header to options.host (without protocol prefix), strip trailing slash
+    if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,"");
 
     var requestThunk = request(opt);
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function(options) {
       body: parsedBody
     };
     // set 'Host' header to options.host (without protocol prefix), strip trailing slash
-    if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,"");
+    if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,'');
 
     var requestThunk = request(opt);
 


### PR DESCRIPTION
Sometimes you want to specify the proxy url with trailing slash in your configuration. In that case, trailing slash must be stripped off the host header to make it work.