### PR TITLE
proxy should not follow redirect by default.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = function(options) {
       url: url + '?' + this.querystring,
       headers: this.header,
       encoding: null,
+      followRedirect: options.followRedirect || false,
       method: this.method,
       body: parsedBody
     };


### PR DESCRIPTION
As a proxy middleware, it should not follow the redirect (301/302 ..) response by default.
I think the version bump to 0.5.0 because it is an incompatible API changes
