### PR TITLE
Support for requestOptions option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.idea

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
     if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3)
 
     if (options.requestOptions) {
-      Object.keys(options.requestOptions).forEach(function (option) { opt[option] = options[option]; });
+      Object.keys(options.requestOptions).forEach(function (option) { opt[option] = options.requestOptions[option]; });
     }
 
     var requestThunk = request(opt);

--- a/index.js
+++ b/index.js
@@ -38,6 +38,10 @@ module.exports = function(options) {
     // set 'Host' header to options.host (without protocol prefix)
     if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3)
 
+    if (options.requestOptions) {
+      Object.keys(options.requestOptions).forEach(function (option) { opt[option] = options[option]; });
+    }
+
     var requestThunk = request(opt);
 
     if (parsedBody) {

--- a/test/index.js
+++ b/test/index.js
@@ -298,4 +298,21 @@ describe('koa-proxy', function() {
       .get('/error')
       .expect(500, done);
   });
+
+  it('should pass along requestOptions', function(done) {
+    var app = koa();
+    app.use(proxy({
+      url: 'http://localhost:1234/class.js',
+      requestOptions: { timeout: 1 }
+    }));
+    var server = http.createServer(app.callback());
+    request(server)
+      .get('/index.js')
+      .expect(function sleep() {
+        // Using the custom assert function to make sure we get a timeout
+        var sleepTime = new Date().getTime() + 3;
+        while(new Date().getTime() < sleepTime) {}
+      })
+      .expect(500, done);
+  });
 });


### PR DESCRIPTION
In order to be able to pass options to the underlying request, this PR adds the option `requestOptions`. 

Everything in that key is just copied down as options to the request. E.g.
```javascript
proxy({
    host: 'http://api.something.org',
    match: /\/api\/(.*)/,
    requestOptions: {
        timeout: 750,
    },
});
```
PS.
Also added IntelliJ files to .gitignore.