### PR TITLE
Support requestOptions as functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,18 +41,13 @@ module.exports = function(options) {
     if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,'');
 
     if (options.requestOptions) {
-      var ctx = this;
-
-      Object.keys(options.requestOptions).forEach(function (optionName) {
-        var optionValue = options.requestOptions[optionName];
-
-        if (typeof optionValue === 'function') {
-          opt[optionName] = optionValue(ctx.request, opt);
-        } else {
-          opt[optionName] = optionValue;
-        }
-      });
+      if (typeof options.requestOptions === 'function') {
+        opt = options.requestOptions(this.request, opt);
+      } else {
+        Object.keys(options.requestOptions).forEach(function (option) { opt[option] = options.requestOptions[option]; });
+      }
     }
+
     var requestThunk = request(opt);
 
     if (parsedBody) {

--- a/index.js
+++ b/index.js
@@ -30,17 +30,28 @@ module.exports = function(options) {
     var parsedBody = getParsedBody(this);
 
     var opt = {
-      url: url + '?' + this.querystring,
+      url: url + (this.querystring ? '?' + this.querystring : ''),
       headers: this.header,
       encoding: null,
       method: this.method,
       body: parsedBody
     };
+
     // set 'Host' header to options.host (without protocol prefix), strip trailing slash
     if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,'');
 
     if (options.requestOptions) {
-      Object.keys(options.requestOptions).forEach(function (option) { opt[option] = options.requestOptions[option]; });
+      var ctx = this;
+
+      Object.keys(options.requestOptions).forEach(function (optionName) {
+        const optionValue = options.requestOptions[optionName];
+
+        if (typeof optionValue === 'function') {
+          opt[optionName] = optionValue(ctx.request, opt);
+        } else {
+          opt[optionName] = optionValue;
+        }
+      });
     }
 
     var requestThunk = request(opt);

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(options) {
       var ctx = this;
 
       Object.keys(options.requestOptions).forEach(function (optionName) {
-        const optionValue = options.requestOptions[optionName];
+        var optionValue = options.requestOptions[optionName];
 
         if (typeof optionValue === 'function') {
           opt[optionName] = optionValue(ctx.request, opt);
@@ -53,7 +53,6 @@ module.exports = function(options) {
         }
       });
     }
-
     var requestThunk = request(opt);
 
     if (parsedBody) {

--- a/test/index.js
+++ b/test/index.js
@@ -346,6 +346,23 @@ describe('koa-proxy', function() {
       .expect(500, done);
   });
 
+  it('should pass along requestOptions when function', function(done) {
+    var app = koa();
+    app.use(proxy({
+      url: 'http://localhost:1234/class.js',
+      requestOptions: { timeout: function(req, opt) { return 1; } }
+    }));
+    var server = http.createServer(app.callback());
+    request(server)
+      .get('/index.js')
+      .expect(function sleep() {
+        // Using the custom assert function to make sure we get a timeout
+        var sleepTime = new Date().getTime() + 3;
+        while(new Date().getTime() < sleepTime) {}
+      })
+      .expect(500, done);
+  });
+
   describe('with cookie jar', function () {
 
     var app = koa();

--- a/test/index.js
+++ b/test/index.js
@@ -350,7 +350,10 @@ describe('koa-proxy', function() {
     var app = koa();
     app.use(proxy({
       url: 'http://localhost:1234/class.js',
-      requestOptions: { timeout: function(req, opt) { return 1; } }
+      requestOptions: function(req, opt) {
+        opt.timeout = 1;
+        return opt;
+      }
     }));
     var server = http.createServer(app.callback());
     request(server)


### PR DESCRIPTION
- Only append '?' if a query string is present
- Support requestOptions also being functions. This allows us to dynamically generate options at call-time for things like timestamp-sensitive authentication headers.
- Added a test that makes sure requestOptions as functions behave in the expected way