### PR TITLE
added preserveHost option

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = function(options) {
     };
 
     // set 'Host' header to options.host (without protocol prefix), strip trailing slash
-    if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,'');
+    if (!options.preserveHost) {
+      if (options.host) opt.headers.host = options.host.slice(options.host.indexOf('://')+3).replace(/\/$/,'');
+    }
 
     if (options.requestOptions) {
       if (typeof options.requestOptions === 'function') {


### PR DESCRIPTION
In some situations a proxy needs to preserve the original host. It should be possible to do it via options analogous to [this apache proxy directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypreservehost).