### PR TITLE
add a yieldNext option

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ module.exports = function(options) {
 
     this.body = res.body;
 
-    if (options.yield_next) {
+    if (options.yieldNext) {
       yield next;
     }
   };

--- a/test/index.js
+++ b/test/index.js
@@ -215,6 +215,26 @@ describe('koa-proxy', function() {
       });
   });
 
+  it('should have option yieldNext', function(done) {
+    var app = koa();
+    app.use(proxy({
+      host: 'http://localhost:1234/',
+      yieldNext: true,
+    }));
+    app.use(function* () {
+      done();
+    })
+    var server = http.createServer(app.callback());
+    request(server)
+      .get('/class.js')
+      .expect(200)
+      .expect('Host', 'localhost:1234')
+      .end(function (err, res) {
+        if (err)
+          return done(err);
+      });
+  });
+
   it('url not match for url', function(done) {
     var app = koa();
     app.use(proxy({


### PR DESCRIPTION
This is the same change as https://github.com/popomore/koa-proxy/pull/16, except I renamed the option to be yieldNext instead of yield_next to be consistent with the other options, and I added a test.