### PR TITLE
Only proxy to match path while options.map is defined and bypass others

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(options) {
         return yield* next;
       }
     }
-    
+
     var parsedBody = getParsedBody(this);
 
     var opt = {
@@ -114,14 +114,12 @@ function resolve(path, options) {
   }
 
   if (typeof options.map === 'object') {
-    if (options.map && options.map[path]) {
-      path = ignoreQuery(options.map[path]);
-    }
+    path = ignoreQuery(options.map[path]);
   } else if (typeof options.map === 'function') {
     path = options.map(path);
   }
 
-  return options.host ? join(options.host, path) : null;
+  return (options.host && path) ? join(options.host, path) : null;
 }
 
 function ignoreQuery(url) {


### PR DESCRIPTION
Only proxy to match path while options.map is defined and bypass
others. So, mutil proxy host will be supported.
e.g:
proxy({
host: 'http://alicdn.com',
map: {
'index.js': 'index-1.js'
}
})
Only index.js will be proxy to http://alicdn.com.
If you want to proxy other path to another host, just define another
proxy!

Change-Id: I4c21d75c81a2360887a6b8a0a1dcec6e93532ed5